### PR TITLE
Cleanup on SIGTERM

### DIFF
--- a/legate.cabal
+++ b/legate.cabal
@@ -22,4 +22,5 @@ executable legate
                        process,
                        text,
                        unordered-containers,
+                       unix,
                        wreq

--- a/legate.cabal
+++ b/legate.cabal
@@ -11,6 +11,7 @@ cabal-version:       >=1.10
 executable legate
   main-is:             legate.hs
   hs-source-dirs:      src
+  ghc-options:         -threaded
   default-language:    Haskell2010
   build-depends:       base >=4.7 && <4.8,
                        aeson,

--- a/legate.cabal
+++ b/legate.cabal
@@ -22,5 +22,5 @@ executable legate
                        process,
                        text,
                        unordered-containers,
-                       unix,
+                       unix >= 2.7.0.0,
                        wreq

--- a/src/Network/Consul/Http.hs
+++ b/src/Network/Consul/Http.hs
@@ -14,8 +14,6 @@ import           Data.Monoid
 import qualified Data.Text as T
 import           Network.Consul.Types
 import           Network.Wreq
-import           System.IO
-import           System.Posix.Signals
 
 
 registerService :: String -> Register Service -> IO ()
@@ -29,12 +27,8 @@ registerCheck url (DeRegister name) = void $ get (url ++ "/v1/agent/check/deregi
 withService :: String -> Register Service -> IO a -> IO a
 withService url s@Register {..} io =
     bracket_ (registerService url s)
-             (deregisterService)
-             (installHandler sigTERM (Catch deregisterService) Nothing >> io)
-  where
-    deregisterService = do
-        putStrLn "Deregistering service..."
-        registerService url . DeRegister $ fromMaybe _regName _regId
+             (registerService url . DeRegister $ fromMaybe _regName _regId)
+             io
 
 kv :: String -> KV -> IO ByteString
 kv url thing = do resp <- case thing of

--- a/src/legate.hs
+++ b/src/legate.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/legate.hs
+++ b/src/legate.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -10,14 +11,16 @@ import           Network.Consul.Http
 import           Network.Consul.Types
 import           Options.Applicative
 import           System.Environment (withArgs)
-import           System.Process
+import           System.Posix.Process
 import           System.Posix.Signals
+import           System.Process
 
 import           Legate.Options
 
 main :: IO ()
 main = do
-    installHandler sigTERM (CatchInfo $ error . show . siginfoSignal) Nothing
+    pgid <- getProcessGroupID
+    installHandler sigTERM (Catch $ putStrLn "Caugh SIGTERM. Raising SIGINT" >> signalProcessGroup sigINT pgid) Nothing
     join $ execParser (info (helper <*> subparser commands)
                           (fullDesc <> progDesc "interact with consul") )
           

--- a/src/legate.hs
+++ b/src/legate.hs
@@ -11,11 +11,14 @@ import           Network.Consul.Types
 import           Options.Applicative
 import           System.Environment (withArgs)
 import           System.Process
+import           System.Posix.Signals
 
 import           Legate.Options
 
 main :: IO ()
-main = join $ execParser (info (helper <*> subparser commands)
+main = do
+    installHandler sigTERM (CatchInfo $ error . show . siginfoSignal) Nothing
+    join $ execParser (info (helper <*> subparser commands)
                           (fullDesc <> progDesc "interact with consul") )
           
 


### PR DESCRIPTION
SIGTERM does not cause a clean exit from the bracket around the process spawned
by `legate exec`.

To route around this problem a signal handler is set up to catch SIGTERM and raise
a SIGINT instead.

Must compile in threaded mode to allow the handler to run asynchronously to the waiting
process.
